### PR TITLE
RSDK-5988 - Add RPI 5 support for csi-cam-pi module

### DIFF
--- a/etc/Dockerfile.mod.pi
+++ b/etc/Dockerfile.mod.pi
@@ -53,16 +53,6 @@ RUN cd ${HOME}/opt/src && \
     ninja -C build install
 RUN rm -rf ${HOME}/opt/src/libcamera
 
-# Set the environment variables for GStreamer plugin path and library path
-# ENV GST_PLUGIN_PATH=/usr/local/lib/aarch64-linux-gnu/gstreamer-1.0
-# ENV LD_LIBRARY_PATH=/usr/local/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
-
-# # Remove GStreamer registry cache to force it to rebuild
-# RUN rm -f ~/.cache/gstreamer-1.0/registry*.bin
-
-# # Re-run gst-inspect to rebuild the GStreamer registry
-# RUN gst-inspect-1.0
-
 # Build and package the CSI camera driver
 ADD ../ /root/opt/src/csi-camera
 RUN cd /root/opt/src && \

--- a/etc/Dockerfile.mod.pi
+++ b/etc/Dockerfile.mod.pi
@@ -2,6 +2,7 @@ ARG BASE_IMG
 
 FROM ${BASE_IMG}
 
+ENV HOME /root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install software-properties-common to get apt-add-repository
@@ -19,7 +20,6 @@ RUN apt-get -y update
 
 # Install GST dev files
 RUN apt-get -y install \
-    libcamera0 \
     libgstreamer1.0-dev \
     libgstreamer1.0-0 \
     gstreamer1.0-x \
@@ -41,6 +41,27 @@ RUN apt-get install libgmock-dev && \
     cmake ./ && \
     make && \
     cp lib/*.a /usr/lib; 
+
+# Install Raspberry Pi libcamera from source
+RUN mkdir -p ${HOME}/opt/src
+RUN apt-get -y install meson
+RUN apt-get -y install libyaml-dev python3-yaml python3-ply python3-jinja2
+RUN cd ${HOME}/opt/src && \
+    git clone https://github.com/raspberrypi/libcamera.git && \
+    cd libcamera && \
+    meson setup build --prefix=/usr && \
+    ninja -C build install
+RUN rm -rf ${HOME}/opt/src/libcamera
+
+# Set the environment variables for GStreamer plugin path and library path
+# ENV GST_PLUGIN_PATH=/usr/local/lib/aarch64-linux-gnu/gstreamer-1.0
+# ENV LD_LIBRARY_PATH=/usr/local/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
+
+# # Remove GStreamer registry cache to force it to rebuild
+# RUN rm -f ~/.cache/gstreamer-1.0/registry*.bin
+
+# # Re-run gst-inspect to rebuild the GStreamer registry
+# RUN gst-inspect-1.0
 
 # Build and package the CSI camera driver
 ADD ../ /root/opt/src/csi-camera

--- a/etc/viam-csi-pi-arm64.yml
+++ b/etc/viam-csi-pi-arm64.yml
@@ -28,7 +28,6 @@ AppDir:
     - sourceline: deb http://archive.raspberrypi.org/debian/ bullseye main
     include:
     - libgstreamer1.0-0:arm64
-    - libcamera0:arm64 
     - gstreamer1.0-x:arm64
     - gstreamer1.0-plugins-base:arm64
     - gstreamer1.0-plugins-good:arm64
@@ -40,12 +39,12 @@ AppDir:
     - /lib/aarch64-linux-gnu/libpthread*
     - /usr/lib/aarch64-linux-gnu/gstreamer-1.0/*
     - /usr/lib/aarch64-linux-gnu/libcamera*
+    - /usr/lib/aarch64-linux-gnu/libcamera/*
     - /usr/lib/libgst*
-    - /usr/share/libcamera*
+    - /usr/share/libcamera/*
     exclude:
     - usr/share/doc
     - usr/share/man
-    # - usr/lib/aarch64-linux-gnu/gconv
   runtime:
     path_mappings:
       - /usr/lib/aarch64-linux-gnu/libcamera/:$APPDIR/usr/lib/aarch64-linux-gnu/libcamera/ 


### PR DESCRIPTION
## Description

- Building latest `libcamera` from RaspberryPi github org which includes 5 support. See this [commit](https://github.com/raspberrypi/libcamera/commit/6eb567e645f9bc95613ec0bc806fd1c3f6a8a02d).
- Small updates to appimage config for pi target.

## Testing
- Tested with IMX477 on RPI 5.